### PR TITLE
Add support for watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     platforms: [
         .macOS(.v11),
         .iOS(.v13),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .watchOS(.v4)
     ],
     products: [
         .library(name: "CloudKitCodable", targets: ["CloudKitCodable"])


### PR DESCRIPTION
This PR proposes restricting watchOS targets to SDK version 4.0 or later. This is when all of the API the library requires became available.

What it doesn't do, and perhaps should, is add CI tests for supported platforms outside of macOS.  