### PR TITLE
Add support for encoding/decoding String and Int enum properties

### DIFF
--- a/Sources/CloudKitCodable/CloudKitCodable.swift
+++ b/Sources/CloudKitCodable/CloudKitCodable.swift
@@ -1,6 +1,0 @@
-public struct CloudKitCodable {
-    public private(set) var text = "Hello, World!"
-
-    public init() {
-    }
-}

--- a/Sources/CloudKitCodable/CloudKitRecordEncoder.swift
+++ b/Sources/CloudKitCodable/CloudKitRecordEncoder.swift
@@ -181,6 +181,10 @@ extension _CloudKitRecordEncoder.KeyedContainer: KeyedEncodingContainerProtocol 
             throw CloudKitRecordEncodingError.referencesNotSupported(key.stringValue)
         } else if let ckValue = value as? CKRecordValue {
             return ckValue
+        } else if let stringValue = (value as? any CloudKitStringEnum)?.rawValue {
+            return stringValue as NSString
+        } else if let intValue = (value as? any CloudKitIntEnum)?.rawValue {
+            return NSNumber(value: Int(intValue))
         } else {
             throw CloudKitRecordEncodingError.unsupportedValueForKey(key.stringValue)
         }

--- a/Sources/CloudKitCodable/CustomCloudKitEncodable.swift
+++ b/Sources/CloudKitCodable/CustomCloudKitEncodable.swift
@@ -37,3 +37,15 @@ public protocol CustomCloudKitDecodable: CloudKitRecordRepresentable & Decodable
 }
 
 public protocol CustomCloudKitCodable: CustomCloudKitEncodable & CustomCloudKitDecodable { }
+
+public protocol CloudKitEnum {
+    static var cloudKitFallbackCase: Self? { get }
+}
+
+public extension CloudKitEnum where Self: CaseIterable {
+    static var cloudKitFallbackCase: Self? { allCases.first }
+}
+
+public protocol CloudKitStringEnum: Codable, RawRepresentable, CloudKitEnum where RawValue == String { }
+
+public protocol CloudKitIntEnum: Codable, RawRepresentable, CloudKitEnum where RawValue == Int { }

--- a/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
@@ -53,4 +53,15 @@ final class CloudKitRecordDecoderTests: XCTestCase {
         XCTAssert(samePersonDecoded.cloudKitIdentifier == "MY-ID")
     }
 
+    func testEnumRoundtrip() throws {
+        let model = TestModelWithEnum.allEnumsPopulated
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        var sameModelDecoded = try CloudKitRecordDecoder().decode(TestModelWithEnum.self, from: record)
+        sameModelDecoded.cloudKitSystemFields = nil
+
+        XCTAssertEqual(sameModelDecoded, model)
+    }
+
 }

--- a/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
@@ -49,5 +49,27 @@ final class CloudKitRecordEncoderTests: XCTestCase {
         XCTAssert(record.recordID.zoneID == zoneID)
         XCTAssert(record.recordID.recordName == "MY-ID")
     }
-    
+
+    func testEnumEncoding() throws {
+        let model = TestModelWithEnum.allEnumsPopulated
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        XCTAssertEqual(record["enumProperty"], "enumCase3")
+        XCTAssertEqual(record["optionalEnumProperty"], "enumCase2")
+        XCTAssertEqual(record["intEnumProperty"], 1)
+        XCTAssertEqual(record["optionalIntEnumProperty"], 2)
+    }
+
+    func testEnumEncodingNilValue() throws {
+        let model = TestModelWithEnum.optionalEnumNil
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        XCTAssertEqual(record["enumProperty"], "enumCase3")
+        XCTAssertNil(record["optionalEnumProperty"])
+        XCTAssertEqual(record["intEnumProperty"], 1)
+        XCTAssertNil(record["optionalIntEnumProperty"])
+    }
+
 }

--- a/Tests/CloudKitCodableTests/TestTypes/TestModelWithEnum.swift
+++ b/Tests/CloudKitCodableTests/TestTypes/TestModelWithEnum.swift
@@ -1,0 +1,37 @@
+import Foundation
+import CloudKitCodable
+
+struct TestModelWithEnum: CustomCloudKitCodable, Hashable {
+    enum MyStringEnum: String, CloudKitStringEnum, CaseIterable {
+        case enumCase0
+        case enumCase1
+        case enumCase2
+        case enumCase3
+    }
+    enum MyIntEnum: Int, CloudKitIntEnum, CaseIterable {
+        case enumCase0
+        case enumCase1
+        case enumCase2
+        case enumCase3
+    }
+    var cloudKitSystemFields: Data?
+    var enumProperty: MyStringEnum
+    var optionalEnumProperty: MyStringEnum?
+    var intEnumProperty: MyIntEnum
+    var optionalIntEnumProperty: MyIntEnum?
+}
+
+extension TestModelWithEnum {
+    static let allEnumsPopulated = TestModelWithEnum(
+        enumProperty: .enumCase3,
+        optionalEnumProperty: .enumCase2,
+        intEnumProperty: .enumCase1,
+        optionalIntEnumProperty: .enumCase2
+    )
+    static let optionalEnumNil = TestModelWithEnum(
+        enumProperty: .enumCase3,
+        optionalEnumProperty: nil,
+        intEnumProperty: .enumCase1,
+        optionalIntEnumProperty: nil
+    )
+}


### PR DESCRIPTION
This introduces a couple of protocols, `CloudKitStringEnum` and `CloudKitIntEnum`.

When a model that conforms to `CustomCloudKitCodable` wants to encode/decode enum properties, the enums can adopt `CloudKitStringEnum` or `CloudKitIntEnum` and `CoudKitRecordEncoder/Decoder` will encode the values to the `CKRecord` as `String` and `Int` respectively.

Both enum protocols adopt `CloudKitEnum`, which has a single requirement:

```swift
public protocol CloudKitEnum {
    static var cloudKitFallbackCase: Self? { get }
}
```

This allows enums to provide a fallback value in case decoding from an unsupported value fails because of new cases being added, for example.

There's a default implementation for enums that conform to `CaseIterable` that uses the first case as the fallback value.