### PR TITLE
Implemented support for nested Codable values

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,9 @@ let package = Package(
     name: "CloudKitCodable",
     platforms: [
         .macOS(.v11),
-        .iOS(.v13),
-        .tvOS(.v13),
-        .watchOS(.v4)
+        .iOS(.v14),
+        .tvOS(.v14),
+        .watchOS(.v5)
     ],
     products: [
         .library(name: "CloudKitCodable", targets: ["CloudKitCodable"])

--- a/Sources/CloudKitCodable/CloudKitAssetValue.swift
+++ b/Sources/CloudKitCodable/CloudKitAssetValue.swift
@@ -1,0 +1,84 @@
+import Foundation
+import CloudKit
+import UniformTypeIdentifiers
+
+/// Adopted by `Codable` types that can be nested in ``CustomCloudKitCodable`` types, represented as `CKAsset` in records.
+///
+/// The corresponding `CKRecord` field is encoded as a `CKAsset` with a file containing the encoded representation of the value.
+///
+/// Implementers can customize the encoding/decoding, file type, and asset file name, but there are default implementations for all of this protocol's requirements.
+public protocol CloudKitAssetValue: Codable {
+
+    /// The default content type for `CKAsset` files representing values of this type.
+    ///
+    /// There's a default implementation that returns `.json`, so by default ``CloudKitAssetValue`` types are encoded as JSON.
+    static var preferredContentType: UTType { get }
+
+    /// The preferred filename for this value when being encoded as a `CKAsset`.
+    ///
+    /// There's a default implementation for a filename with the format `<type>-<uuid>.(json/plist)`,
+    /// and a default implementation for `Identifiable` types that uses the `id` property instead of a random UUID.
+    var filename: String { get }
+
+    /// Encodes this value as data.
+    ///
+    /// There's a default implementation that uses `JSONEncoder`/`PropertyListDecoder` according to the ``preferredContentType`` property.
+    func encoded() throws -> Data
+
+    /// Decodes an instance of this type from encoded data.
+    /// - Parameters:
+    ///   - data: The encoded value data.
+    ///   - type: Determines the type of decoder to be used.
+    /// - Returns: The instance of the type.
+    ///
+    /// There is a default implementation supporting JSON and PLIST types that uses `JSONDecoder`/`PropertyListDecoder`.
+    static func decoded(from data: Data, type: UTType) throws -> Self
+}
+
+// MARK: - Default Implementations
+
+public extension CloudKitAssetValue {
+    /// Default implementation that returns `.json`, so the value is encoded as JSON data.
+    static var preferredContentType: UTType { .json }
+}
+
+public extension CloudKitAssetValue {
+    /// The file extension (including the leading `.`), computed according to ``preferredContentType``.
+    static var filenameSuffix: String { Self.preferredContentType.preferredFilenameExtension.flatMap { ".\($0)" } ?? "" }
+
+    /// The file name (including extension) for this value when encoded into a `CKAsset`.
+    var filename: String { [String(describing: Self.self), UUID().uuidString].joined(separator: "-") + Self.filenameSuffix }
+}
+
+public extension CloudKitAssetValue where Self: Identifiable {
+    /// The file name (including extension) for this value when encoded into a `CKAsset`.
+    /// Uses the `id` property from `Identifiable` conformance.
+    var filename: String { [String(describing: Self.self), String(describing: id)].joined(separator: "-") + Self.filenameSuffix }
+}
+
+public extension CloudKitAssetValue {
+    func encoded() throws -> Data {
+        let type = Self.preferredContentType
+        if type.conforms(to: .json) {
+            return try JSONEncoder.nestedCloudKitValue.encode(self)
+        } else if type.conforms(to: .xmlPropertyList) {
+            return try PropertyListEncoder.nestedCloudKitValueXML.encode(self)
+        } else if type.conforms(to: .binaryPropertyList) {
+            return try PropertyListEncoder.nestedCloudKitValueBinary.encode(self)
+        } else if type.conforms(to: .propertyList) {
+            return try PropertyListEncoder.nestedCloudKitValueXML.encode(self)
+        } else {
+            throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "Unsupported content type \"\(type.identifier)\": the default implementation only supports JSON and PLIST"))
+        }
+    }
+
+    static func decoded(from data: Data, type: UTType) throws -> Self {
+        if type.conforms(to: .json) {
+            return try JSONDecoder.nestedCloudKitValue.decode(Self.self, from: data)
+        } else if type.conforms(to: .propertyList) {
+            return try PropertyListDecoder.nestedCloudKitValue.decode(Self.self, from: data)
+        } else {
+            throw DecodingError.typeMismatch(Self.self, .init(codingPath: [], debugDescription: "Unsupported content type \"\(type.identifier)\": the default implementation only supports JSON and PLIST"))
+        }
+    }
+}

--- a/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
@@ -64,4 +64,25 @@ final class CloudKitRecordDecoderTests: XCTestCase {
         XCTAssertEqual(sameModelDecoded, model)
     }
 
+    func testNestedRoundtrip() throws {
+        let model = TestParent.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        var sameModelDecoded = try CloudKitRecordDecoder().decode(TestParent.self, from: record)
+        sameModelDecoded.cloudKitSystemFields = nil
+
+        XCTAssertEqual(sameModelDecoded, model)
+    }
+
+    func testNestedRoundtripCollection() throws {
+        let model = TestParentCollection.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        var sameModelDecoded = try CloudKitRecordDecoder().decode(TestParentCollection.self, from: record)
+        sameModelDecoded.cloudKitSystemFields = nil
+
+        XCTAssertEqual(sameModelDecoded, model)
+    }
 }

--- a/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
@@ -107,4 +107,15 @@ final class CloudKitRecordDecoderTests: XCTestCase {
 
         XCTAssertEqual(sameModelDecoded, model)
     }
+
+    func testCustomAssetRoundtrip() throws {
+        let model = TestModelCustomAsset.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        var sameModelDecoded = try CloudKitRecordDecoder().decode(TestModelCustomAsset.self, from: record)
+        sameModelDecoded.cloudKitSystemFields = nil
+
+        XCTAssertEqual(sameModelDecoded, model)
+    }
 }

--- a/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordDecoderTests.swift
@@ -75,6 +75,28 @@ final class CloudKitRecordDecoderTests: XCTestCase {
         XCTAssertEqual(sameModelDecoded, model)
     }
 
+    func testNestedRoundtripOptionalChild() throws {
+        let model = TestParentOptionalChild.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        var sameModelDecoded = try CloudKitRecordDecoder().decode(TestParentOptionalChild.self, from: record)
+        sameModelDecoded.cloudKitSystemFields = nil
+
+        XCTAssertEqual(sameModelDecoded, model)
+    }
+
+    func testNestedRoundtripOptionalChildNil() throws {
+        let model = TestParentOptionalChild.testNilChild
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        var sameModelDecoded = try CloudKitRecordDecoder().decode(TestParentOptionalChild.self, from: record)
+        sameModelDecoded.cloudKitSystemFields = nil
+
+        XCTAssertEqual(sameModelDecoded, model)
+    }
+
     func testNestedRoundtripCollection() throws {
         let model = TestParentCollection.test
 

--- a/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
@@ -85,6 +85,28 @@ final class CloudKitRecordEncoderTests: XCTestCase {
         XCTAssertEqual(record["child"], encodedChild)
     }
 
+    func testNestedEncodingOptional() throws {
+        let model = TestParentOptionalChild.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        let encodedChild = """
+        {"name":"Hello Optional Child Name","value":"Hello Optional Child Value"}
+        """.UTF8Data()
+
+        XCTAssertEqual(record["parentName"], "Hello Parent")
+        XCTAssertEqual(record["child"], encodedChild)
+    }
+
+    func testNestedEncodingOptionalNil() throws {
+        let model = TestParentOptionalChild.testNilChild
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        XCTAssertEqual(record["parentName"], "Hello Parent")
+        XCTAssertNil(record["child"])
+    }
+
     func testNestedEncodingCollection() throws {
         let model = TestParentCollection.test
 

--- a/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
@@ -72,4 +72,34 @@ final class CloudKitRecordEncoderTests: XCTestCase {
         XCTAssertNil(record["optionalIntEnumProperty"])
     }
 
+    func testNestedEncoding() throws {
+        let model = TestParent.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        let encodedChild = """
+        {"name":"Hello Child Name","value":"Hello Child Value"}
+        """.UTF8Data()
+
+        XCTAssertEqual(record["parentName"], "Hello Parent")
+        XCTAssertEqual(record["child"], encodedChild)
+    }
+
+    func testNestedEncodingCollection() throws {
+        let model = TestParentCollection.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        let encodedChildren = """
+        [{"name":"0 - Hello Child Name","value":"0 - Hello Child Value"},{"name":"1 - Hello Child Name","value":"1 - Hello Child Value"},{"name":"2 - Hello Child Name","value":"2 - Hello Child Value"}]
+        """.UTF8Data()
+
+        XCTAssertEqual(record["parentName"], "Hello Parent Collection")
+        XCTAssertEqual(record["children"], encodedChildren)
+    }
+
+}
+
+extension String {
+    func UTF8Data() -> Data { Data(utf8) }
 }

--- a/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
+++ b/Tests/CloudKitCodableTests/CloudKitRecordEncoderTests.swift
@@ -120,6 +120,30 @@ final class CloudKitRecordEncoderTests: XCTestCase {
         XCTAssertEqual(record["children"], encodedChildren)
     }
 
+    func testCustomAssetEncoding() throws {
+        let model = TestModelCustomAsset.test
+
+        let record = try CloudKitRecordEncoder().encode(model)
+
+        XCTAssertEqual(record["title"], model.title)
+        guard let asset = record["contents"] as? CKAsset else {
+            XCTFail("Expected CloudKitAssetValue to be encoded as CKAsset")
+            return
+        }
+
+        let url = asset.fileURL!
+
+        XCTAssertEqual(url.lastPathComponent, "Contents-MyID.json")
+
+        let encodedAsset = """
+        {"contentProperty1":"Prop1","contentProperty2":"Prop2","contentProperty3":"Prop3","contentProperty4":"Prop4","id":"MyID"}
+        """.UTF8Data()
+
+        let assetData = try Data(contentsOf: url)
+
+        XCTAssertEqual(assetData, encodedAsset)
+    }
+
 }
 
 extension String {

--- a/Tests/CloudKitCodableTests/TestTypes/TestModelCustomAsset.swift
+++ b/Tests/CloudKitCodableTests/TestTypes/TestModelCustomAsset.swift
@@ -1,0 +1,28 @@
+import Foundation
+import CloudKitCodable
+
+struct TestModelCustomAsset: Hashable, CustomCloudKitCodable {
+    struct Contents: Identifiable, Hashable, CloudKitAssetValue {
+        var id: String
+        var contentProperty1: String
+        var contentProperty2: String
+        var contentProperty3: String
+        var contentProperty4: String
+    }
+    var cloudKitSystemFields: Data?
+    var title: String
+    var contents: Contents
+}
+
+extension TestModelCustomAsset {
+    static let test = TestModelCustomAsset(
+        title: "Hello Title",
+        contents: .init(
+            id: "MyID",
+            contentProperty1: "Prop1",
+            contentProperty2: "Prop2",
+            contentProperty3: "Prop3",
+            contentProperty4: "Prop4"
+        )
+    )
+}

--- a/Tests/CloudKitCodableTests/TestTypes/TestNestedModel.swift
+++ b/Tests/CloudKitCodableTests/TestTypes/TestNestedModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+import CloudKitCodable
+
+struct TestParent: CustomCloudKitCodable, Hashable {
+    struct TestChild: Codable, Hashable {
+        var name: String
+        var value: String
+    }
+    var cloudKitSystemFields: Data?
+    var parentName: String
+    var child: TestChild
+    var dataProperty: Data
+}
+
+struct TestParentCollection: CustomCloudKitCodable, Hashable {
+    struct TestCollectionChild: Codable, Hashable {
+        var name: String
+        var value: String
+    }
+    var cloudKitSystemFields: Data?
+    var parentName: String
+    var children: [TestCollectionChild]
+    /// This data property is used to ensure that the special handling of `Data` for JSON-encoded children
+    /// does not break encoding/decoding of regular data fields.
+    var dataProperty: Data
+}
+
+extension TestParent {
+    static let test = TestParent(
+        parentName: "Hello Parent",
+        child: .init(
+            name: "Hello Child Name",
+            value: "Hello Child Value"
+        ),
+        dataProperty: Data([0xFF])
+    )
+}
+
+extension TestParentCollection {
+    static let test = TestParentCollection(
+        parentName: "Hello Parent Collection",
+        children: [
+            .init(
+                name: "0 - Hello Child Name",
+                value: "0 - Hello Child Value"
+            ),
+            .init(
+                name: "1 - Hello Child Name",
+                value: "1 - Hello Child Value"
+            ),
+            .init(
+                name: "2 - Hello Child Name",
+                value: "2 - Hello Child Value"
+            ),
+        ],
+        dataProperty: Data([0xFF])
+    )
+}

--- a/Tests/CloudKitCodableTests/TestTypes/TestNestedModel.swift
+++ b/Tests/CloudKitCodableTests/TestTypes/TestNestedModel.swift
@@ -12,6 +12,17 @@ struct TestParent: CustomCloudKitCodable, Hashable {
     var dataProperty: Data
 }
 
+struct TestParentOptionalChild: CustomCloudKitCodable, Hashable {
+    struct TestOptionalChild: Codable, Hashable {
+        var name: String
+        var value: String
+    }
+    var cloudKitSystemFields: Data?
+    var parentName: String
+    var child: TestOptionalChild?
+    var dataProperty: Data
+}
+
 struct TestParentCollection: CustomCloudKitCodable, Hashable {
     struct TestCollectionChild: Codable, Hashable {
         var name: String
@@ -32,6 +43,22 @@ extension TestParent {
             name: "Hello Child Name",
             value: "Hello Child Value"
         ),
+        dataProperty: Data([0xFF])
+    )
+}
+
+extension TestParentOptionalChild {
+    static let test = TestParentOptionalChild(
+        parentName: "Hello Parent",
+        child: .init(
+            name: "Hello Optional Child Name",
+            value: "Hello Optional Child Value"
+        ),
+        dataProperty: Data([0xFF])
+    )
+    static let testNilChild = TestParentOptionalChild(
+        parentName: "Hello Parent",
+        child: nil,
         dataProperty: Data([0xFF])
     )
 }


### PR DESCRIPTION
This implements support for encoding `CustomCloudKitCodable` types that have nested `Codable` properties.

**This does not** add support for `CKReference`, it's meant to be used for models that have lightweight children that can be encoded into the `CKRecord` itself. The need for this came about as I was working on changes to a CMS that uses the CloudKit public database for publishing.

Sometimes models have small nested types that are used for grouping, such as the `Theme` struct in the example below. In my particular use case, it wouldn't make sense for `Theme` to be a reference, and flattening the `Post` type to have all of the properties from `Theme` would break existing code and abstractions.

With the changes in this PR, types conforming to `CustomCloudKitCodable` can have properties with custom types that conform to `Codable`, and those will be encoded into the `CKRecord` as a `Data` field with the JSON-encoded representation of the value. Arrays of custom types conforming to `Codable` are also supported.

Decoding works as expected: the `Data` value of the field is read and decoded using `JSONDecoder`.

```swift
struct Post: CustomCloudKitCodable {
    struct Theme: Codable {
        var titleColor: String
        var backgroundColor: String
    }
    var cloudKitSystemFields: Data?
    var id: UUID
    var title: String
    var theme: Theme
}
```

## Custom Asset Types

Encoding simple nested values as JSON directly into the record itself is fine for very small types, but `CKRecord` has a hard limit of `1MB` per record, which might be reached if a type has a nested value with lots of properties (or lots of nested values).

To address this, values nested in `CustomCloudKitCodable` can conform to `CloudKitAssetValue`.

Types conforming to `CloudKitAssetValue` will be encoded as `CKAsset`. The protocol includes support for customizing the file type, name, and for implementing completely custom encoding and decoding, but there are default implementations for all of its requirements, so just declaring conformance to `CloudKitAssetValue` will work for most use cases.