### PR TITLE
Update Package to require watchOS 7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .macOS(.v11),
         .iOS(.v14),
         .tvOS(.v14),
-        .watchOS(.v5)
+        .watchOS(.v7)
     ],
     products: [
         .library(name: "CloudKitCodable", targets: ["CloudKitCodable"])


### PR DESCRIPTION
The required watchOS target is set to `v5` in the `Package.swift` - however numerous APIs that are used aren't available until watchOS 6/7 (such as  `UTType`)

<img width="1512" alt="Screenshot 2024-09-02 at 11 32 25" src="https://github.com/user-attachments/assets/763dfbf6-7fa9-400e-b9f6-50e41f63f591">

Bumps the supported watchOS version to `v7`.